### PR TITLE
fix(ProposalCard): surface delete errors instead of swallowing them (#40)

### DIFF
--- a/src/ProposalCard.test.tsx
+++ b/src/ProposalCard.test.tsx
@@ -130,6 +130,41 @@ describe('ProposalCard', () => {
     expect(screen.getByText('Delete Proposal?')).toBeDefined()
   })
 
+  // Regression for issue #40: handleDelete used to swallow errors silently,
+  // so a failed deleteProposal call left the user with no feedback. Mirror
+  // the handleSubmit/handleReject pattern: surface the error in-place.
+  it('surfaces deleteProposal failures next to the confirm dialog', async () => {
+    const user = userEvent.setup()
+    const failingDelete = mock(async () => {
+      throw new Error('network is down')
+    })
+    render(
+      <ProposalCard
+        proposal={baseProposal}
+        userId="user-1"
+        onUpdated={() => {}}
+        onDeleted={() => {}}
+        onSubmitted={() => {}}
+        updateProposal={mockUpdateProposal}
+        deleteProposal={failingDelete}
+        submitProposal={mockSubmitProposal}
+        rejectProposal={mockRejectProposal}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    // Two "Delete" buttons exist after the dialog opens (the original on
+    // the card, plus the confirm button). The dialog version is inside the
+    // confirm UI, which also contains the cancel button.
+    const confirmButton = screen
+      .getAllByRole('button', { name: 'Delete' })
+      .at(-1) as HTMLButtonElement
+    await user.click(confirmButton)
+
+    expect(failingDelete).toHaveBeenCalledTimes(1)
+    expect(await screen.findByText('network is down')).toBeDefined()
+  })
+
   it('shows resubmit button for coordinator + REJECTED', () => {
     const rejectedProposal = { ...baseProposal, state: 'REJECTED' as const }
     render(

--- a/src/ProposalCard.tsx
+++ b/src/ProposalCard.tsx
@@ -76,6 +76,8 @@ export default function ProposalCard({
   const [rejectError, setRejectError] = useState('')
   const [resubmitting, setResubmitting] = useState(false)
   const [resubmitError, setResubmitError] = useState('')
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState('')
 
   const isOwner = userId === proposal.proposerUserId
   const isDraft = proposal.state === 'DRAFT'
@@ -124,11 +126,20 @@ export default function ProposalCard({
   }
 
   async function handleDelete() {
+    // React ErrorBoundary doesn't catch errors thrown from event handlers,
+    // so a thrown error here would surface as an unhandled promise rejection
+    // and the user would have no idea whether the delete succeeded. Mirror
+    // the handleSubmit / handleReject / handleResubmit pattern: surface the
+    // error in a local state slot and render it next to the action.
+    setDeleteError('')
+    setDeleting(true)
     try {
       await deleteProposal(proposal.$id, userId)
+      // The card unmounts on onDeleted; no need to clear `deleting` here.
       onDeleted(proposal.$id)
-    } catch (_err) {
-      // Errors propagate to ErrorBoundary
+    } catch (err: unknown) {
+      setDeleteError(err instanceof Error ? err.message : String(err))
+      setDeleting(false)
     }
   }
 
@@ -308,6 +319,7 @@ export default function ProposalCard({
               <button
                 type="button"
                 onClick={() => setShowDeleteConfirm(false)}
+                disabled={deleting}
                 style={styles.cancelButton}
               >
                 Cancel
@@ -315,11 +327,13 @@ export default function ProposalCard({
               <button
                 type="button"
                 onClick={handleDelete}
+                disabled={deleting}
                 style={styles.confirmDeleteButton}
               >
-                Delete
+                {deleting ? 'Deleting…' : 'Delete'}
               </button>
             </div>
+            {deleteError && <p style={styles.errorText}>{deleteError}</p>}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Closes #40.

\`handleDelete\` was wrapping \`deleteProposal\` in a try/catch that ignored the error with the comment *Errors propagate to ErrorBoundary* — but React ErrorBoundaries do not catch errors thrown from event handlers. The user got no feedback when the delete failed: the confirm dialog stayed open with no indication that the underlying mutation had errored, and the only signal in dev was an unhandled promise rejection in the console.

## Changes

- \`src/ProposalCard.tsx\`: mirror the established \`handleSubmit\` / \`handleReject\` / \`handleResubmit\` pattern — a \`deleteError\` state slot, populated on failure, rendered next to the confirm-dialog buttons via the same \`styles.errorText\` used by the other actions. Added a \`deleting\` flag to disable both *Cancel* and *Delete* while the request is in flight (preventing duplicate clicks) and to swap the button label for *Deleting…*. The success path is unchanged — it still calls \`onDeleted\`, which unmounts the card.
- \`src/ProposalCard.test.tsx\`: regression test that mocks a \`deleteProposal\` that throws and asserts the error text appears in the dialog after the user confirms.

## Test plan

- [x] \`bun run test src/ProposalCard.test.tsx\` — 11/11 pass (10 prior + 1 new)
- [x] \`bun run lint src/ProposalCard.tsx src/ProposalCard.test.tsx\` — clean
- [x] \`bun run build\` — clean
- [x] pre-commit \`biome check\` hook — clean